### PR TITLE
Update Topicprefixes for 3.2 (drop support for 3.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,20 +26,19 @@ matrix:
       env: DB=mysqli
     - php: 7.1
       env: DB=mysqli
-    - php: nightly
+    - php: 7.2
       env: DB=mysqli
-    - php: hhvm
+    - php: nightly
       env: DB=mysqli
   allow_failures:
     - php: nightly
-    - php: hhvm
   fast_finish: true
 
 env:
   global:
     - EXTNAME="phpbb/topicprefixes" # CHANGE name of the extension HERE
     - SNIFF="1"        # Should we run code sniffer on your code?
-    - IMAGE_ICC="1"    # Should we run icc profile sniffer on your images?
+    - IMAGE_ICC="0"    # Should we run icc profile sniffer on your images?
     - EPV="1"          # Should we run EPV (Extension Pre Validator) on your code?
     - PHPBB_BRANCH="3.2.x"
 

--- a/acp/topic_prefixes_module.php
+++ b/acp/topic_prefixes_module.php
@@ -27,11 +27,11 @@ class topic_prefixes_module
 	{
 		global $phpbb_container;
 
-		$user = $phpbb_container->get('user');
-		$user->add_lang('acp/forums');
-		$user->add_lang_ext('phpbb/topicprefixes', 'acp_topic_prefixes');
+		$lang = $phpbb_container->get('language');
+		$lang->add_lang('acp/forums');
+		$lang->add_lang('acp_topic_prefixes', 'phpbb/topicprefixes');
 		$this->tpl_name   = 'acp_topic_prefixes';
-		$this->page_title = $user->lang('TOPIC_PREFIXES');
+		$this->page_title = $lang->lang('TOPIC_PREFIXES');
 
 		$admin_controller = $phpbb_container->get('phpbb.topicprefixes.admin_controller');
 		$admin_controller->set_u_action($this->u_action)->main();

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 	"extra": {
 		"display-name": "phpBB Topic Prefixes",
 		"soft-require": {
-			"phpbb/phpbb": ">=3.1.4"
+			"phpbb/phpbb": ">=3.2.0"
 		}
 	}
 }

--- a/config/services.yml
+++ b/config/services.yml
@@ -7,7 +7,7 @@ services:
         arguments:
             - '@phpbb.topicprefixes.manager'
             - '@request'
-            - '@user'
+            - '@language'
         tags:
             - { name: event.listener }
 
@@ -15,6 +15,7 @@ services:
         class: phpbb\topicprefixes\controller\admin_controller
         arguments:
             - '@phpbb.topicprefixes.manager'
+            - '@language'
             - '@log'
             - '@request'
             - '@template'

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -59,7 +59,7 @@ class admin_controller
 	 * Constructor
 	 *
 	 * @param manager  $manager         Topic prefixes manager object
-	 * @param language $language        [h[BB language object
+	 * @param language $language        phpBB language object
 	 * @param log      $log             phpBB log object
 	 * @param request  $request         phpBB request object
 	 * @param template $template        phpBB template object

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -10,6 +10,7 @@
 
 namespace phpbb\topicprefixes\controller;
 
+use phpbb\language\language;
 use phpbb\log\log;
 use phpbb\request\request;
 use phpbb\template\template;
@@ -23,6 +24,9 @@ class admin_controller
 {
 	/** @var manager Topic prefixes manager object */
 	protected $manager;
+
+	/** @var language phpBB language object */
+	protected $language;
 
 	/** @var log phpBB log object */
 	protected $log;
@@ -55,6 +59,7 @@ class admin_controller
 	 * Constructor
 	 *
 	 * @param manager  $manager         Topic prefixes manager object
+	 * @param language $language        [h[BB language object
 	 * @param log      $log             phpBB log object
 	 * @param request  $request         phpBB request object
 	 * @param template $template        phpBB template object
@@ -62,9 +67,10 @@ class admin_controller
 	 * @param string   $phpbb_root_path phpBB root path
 	 * @param string   $phpEx           PHP extension
 	 */
-	public function __construct(manager $manager, log $log, request $request, template $template, user $user, $phpbb_root_path, $phpEx)
+	public function __construct(manager $manager, language $language, log $log, request $request, template $template, user $user, $phpbb_root_path, $phpEx)
 	{
 		$this->manager = $manager;
+		$this->language = $language;
 		$this->log = $log;
 		$this->request = $request;
 		$this->template = $template;
@@ -201,7 +207,7 @@ class admin_controller
 			$this->trigger_message('TOPIC_PREFIX_DELETED');
 		}
 
-		confirm_box(false, $this->user->lang('DELETE_TOPIC_PREFIX_CONFIRM'), build_hidden_fields([
+		confirm_box(false, $this->language->lang('DELETE_TOPIC_PREFIX_CONFIRM'), build_hidden_fields([
 			'mode'		=> 'manage',
 			'action'	=> 'delete',
 			'prefix_id'	=> $prefix_id,
@@ -284,7 +290,7 @@ class admin_controller
 	 */
 	protected function trigger_message($message = '', $error = E_USER_NOTICE)
 	{
-		trigger_error($this->user->lang($message) . adm_back_link("{$this->u_action}&amp;forum_id={$this->forum_id}"), $error);
+		trigger_error($this->language->lang($message) . adm_back_link("{$this->u_action}&amp;forum_id={$this->forum_id}"), $error);
 	}
 
 	/**

--- a/event/listener.php
+++ b/event/listener.php
@@ -10,9 +10,9 @@
 
 namespace phpbb\topicprefixes\event;
 
+use phpbb\language\language;
 use phpbb\request\request;
 use phpbb\topicprefixes\prefixes\manager;
-use phpbb\user;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -31,9 +31,9 @@ class listener implements EventSubscriberInterface
 	protected $request;
 
 	/**
-	 * @var user User object
+	 * @var language Language object
 	 */
-	protected $user;
+	protected $language;
 
 	/**
 	 * @var array An array of topic prefixes
@@ -55,15 +55,15 @@ class listener implements EventSubscriberInterface
 	/**
 	 * Listener constructor
 	 *
-	 * @param manager $manager Topic prefixes manager
-	 * @param request $request Request object
-	 * @param user    $user    Language object
+	 * @param manager  $manager  Topic prefixes manager
+	 * @param request  $request  Request object
+	 * @param language $language Language object
 	 */
-	public function __construct(manager $manager, request $request, user $user)
+	public function __construct(manager $manager, request $request, language $language)
 	{
 		$this->manager = $manager;
 		$this->request = $request;
-		$this->user = $user;
+		$this->language = $language;
 	}
 
 	/**
@@ -80,7 +80,7 @@ class listener implements EventSubscriberInterface
 			return;
 		}
 
-		$this->user->add_lang_ext('phpbb/topicprefixes', 'topic_prefixes');
+		$this->language->add_lang('topic_prefixes', 'phpbb/topicprefixes');
 
 		// Get prefixes for the current forum
 		$this->prefixes = $this->manager->get_active_prefixes($event['forum_id']);

--- a/ext.php
+++ b/ext.php
@@ -25,12 +25,12 @@ class ext extends \phpbb\extension\base
 	 * The current phpBB version should meet or exceed
 	 * the minimum version required by this extension:
 	 *
-	 * Requires phpBB 3.1.4 and PHP 5.4, due to use of shortened array syntax
+	 * Requires phpBB 3.2.0 and PHP 5.4
 	 *
 	 * @return bool
 	 */
 	public function is_enableable()
 	{
-		return phpbb_version_compare(PHPBB_VERSION, '3.1.4', '>=') && phpbb_version_compare(PHP_VERSION, '5.4', '>=');
+		return phpbb_version_compare(PHPBB_VERSION, '3.2.0', '>=') && phpbb_version_compare(PHP_VERSION, '5.4', '>=');
 	}
 }

--- a/tests/controller/add_prefix_test.php
+++ b/tests/controller/add_prefix_test.php
@@ -45,7 +45,7 @@ class add_prefix_test extends admin_controller_base
 		{
 			self::$valid_form = $valid_form;
 
-			$this->request->expects(static::any())
+			$this->request->expects(static::once())
 				->method('is_set_post')
 				->will(static::returnValue($submit));
 

--- a/tests/controller/admin_controller_base.php
+++ b/tests/controller/admin_controller_base.php
@@ -30,6 +30,9 @@ class admin_controller_base extends \phpbb_test_case
 	/** @var \phpbb\topicprefixes\prefixes\manager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $manager;
 
+	/** @var \phpbb\language\language */
+	protected $language;
+
 	/** @var \phpbb\log\log|\PHPUnit_Framework_MockObject_MockObject */
 	protected $log;
 
@@ -55,6 +58,8 @@ class admin_controller_base extends \phpbb_test_case
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->language = new \phpbb\language\language(new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx));
+
 		$this->log = $this->getMockBuilder('\phpbb\log\log')
 			->disableOriginalConstructor()
 			->getMock();
@@ -62,12 +67,14 @@ class admin_controller_base extends \phpbb_test_case
 		$this->request = $this->getMockBuilder('\phpbb\request\request')
 			->disableOriginalConstructor()
 			->getMock();
+
 		$this->template = $this->getMockBuilder('\phpbb\template\template')
 			->disableOriginalConstructor()
 			->getMock();
+
 		$this->user = $this->getMockBuilder('\phpbb\user')
 			->setConstructorArgs(array(
-				new \phpbb\language\language(new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx)),
+				$this->language,
 				'\phpbb\datetime'
 			))
 			->getMock();
@@ -76,6 +83,7 @@ class admin_controller_base extends \phpbb_test_case
 			->setMethods(array('get_forum_info', 'log'))
 			->setConstructorArgs(array(
 				$this->manager,
+				$this->language,
 				$this->log,
 				$this->request,
 				$this->template,

--- a/tests/controller/display_settings_test.php
+++ b/tests/controller/display_settings_test.php
@@ -41,14 +41,14 @@ class display_settings_test extends admin_controller_base
 	 */
 	public function test_display_settings($prefix_count, $forum_id)
 	{
-		$this->manager->expects(static::any())
+		$this->manager->expects(static::once())
 			->method('get_prefixes')
 			->will(static::returnValue(array_pad(array(), $prefix_count, 0)));
 
 		$this->template->expects(static::exactly($prefix_count))
 			->method('assign_block_vars');
 
-		$this->template->expects(static::any())
+		$this->template->expects(static::once())
 			->method('assign_vars')
 			->with(array(
 				'S_FORUM_OPTIONS'	=> '#select menu#',

--- a/tests/controller/edit_prefix_test.php
+++ b/tests/controller/edit_prefix_test.php
@@ -41,7 +41,7 @@ class edit_prefix_test extends admin_controller_base
 	 */
 	public function test_edit_prefix($prefix_id, $valid_form)
 	{
-		$this->request->expects(static::any())
+		$this->request->expects(static::once())
 			->method('variable')
 			->with(static::anything())
 			->will(static::returnValueMap(array(

--- a/tests/controller/main_test.php
+++ b/tests/controller/main_test.php
@@ -28,6 +28,7 @@ class main_test extends admin_controller_base
 			->setMethods(array('add_prefix', 'edit_prefix', 'delete_prefix', 'move_prefix', 'display_settings'))
 			->setConstructorArgs(array(
 				$this->manager,
+				$this->language,
 				$this->log,
 				$this->request,
 				$this->template,

--- a/tests/controller/move_prefix_test.php
+++ b/tests/controller/move_prefix_test.php
@@ -46,7 +46,7 @@ class move_prefix_test extends admin_controller_base
 	 */
 	public function test_move_prefix($prefix_id, $direction, $valid_form)
 	{
-		$this->request->expects(static::any())
+		$this->request->expects(static::once())
 			->method('variable')
 			->with(static::anything())
 			->will(static::returnValueMap(array(
@@ -60,22 +60,19 @@ class move_prefix_test extends admin_controller_base
 			$this->manager->expects(static::never())
 				->method('move_prefix');
 		}
+		else if ($prefix_id === 0)
+		{
+			$this->setExpectedTriggerError(E_USER_WARNING);
+			$this->manager->expects(static::once())
+				->method('move_prefix')
+				->with(static::equalTo(0), static::stringContains($direction))
+				->will(static::throwException(new \OutOfBoundsException));
+		}
 		else
 		{
-			if ($prefix_id === 0)
-			{
-				$this->setExpectedTriggerError(E_USER_WARNING);
-				$this->manager->expects(static::once())
-					->method('move_prefix')
-					->with(static::equalTo(0), static::stringContains($direction))
-					->will(static::throwException(new \OutOfBoundsException));
-			}
-			else
-			{
-				$this->manager->expects(static::once())
-					->method('move_prefix')
-					->with(static::equalTo($prefix_id), static::stringContains($direction));
-			}
+			$this->manager->expects(static::once())
+				->method('move_prefix')
+				->with(static::equalTo($prefix_id), static::stringContains($direction));
 		}
 
 		$this->controller->move_prefix($prefix_id, $direction);

--- a/tests/dbal/manager_base.php
+++ b/tests/dbal/manager_base.php
@@ -25,7 +25,7 @@ class manager_base extends \phpbb_database_test_case
 	/**
 	 * @inheritdoc
 	 */
-	static protected function setup_extensions()
+	protected static function setup_extensions()
 	{
 		return ['phpbb/topicprefixes'];
 	}

--- a/tests/dbal/simple_test.php
+++ b/tests/dbal/simple_test.php
@@ -21,7 +21,7 @@ class simple_test extends \phpbb_database_test_case
 	/**
 	 * @inheritdoc
 	 */
-	static protected function setup_extensions()
+	protected static function setup_extensions()
 	{
 		return ['phpbb/topicprefixes'];
 	}

--- a/tests/event/listener_test.php
+++ b/tests/event/listener_test.php
@@ -228,7 +228,7 @@ class listener_test extends \phpbb_test_case
 
 		$data = new \phpbb\event\data($test_data);
 
-		$this->manager->expects($this->any())
+		$this->manager->expects($this->atMost(1))
 			->method('get_active_prefixes')
 			->will($this->returnValue($prefixes));
 
@@ -348,7 +348,7 @@ class listener_test extends \phpbb_test_case
 				array('topic_prefix', 0, false, \phpbb\request\request_interface::REQUEST, $prefix_id),
 			)));
 
-		$this->manager->expects($this->any())
+		$this->manager->expects($this->atMost(1))
 			->method('get_prefix')
 			->will($this->returnValue($prefix));
 

--- a/tests/event/listener_test.php
+++ b/tests/event/listener_test.php
@@ -28,9 +28,9 @@ class listener_test extends \phpbb_test_case
 	protected $request;
 
 	/**
-	 * @var \PHPUnit_Framework_MockObject_MockObject|\phpbb\user
+	 * @var \phpbb\language\language
 	 */
-	protected $user;
+	protected $language;
 
 	/**
 	 * @inheritdoc
@@ -50,12 +50,7 @@ class listener_test extends \phpbb_test_case
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->user = $this->getMockBuilder('\phpbb\user')
-			->setConstructorArgs(array(
-				new \phpbb\language\language(new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx)),
-				'\phpbb\datetime'
-			))
-			->getMock();
+		$this->language = new \phpbb\language\language(new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx));
 	}
 
 	/**
@@ -85,7 +80,7 @@ class listener_test extends \phpbb_test_case
 		$this->listener = new \phpbb\topicprefixes\event\listener(
 			$this->manager,
 			$this->request,
-			$this->user
+			$this->language
 		);
 	}
 

--- a/tests/functional/functional_test.php
+++ b/tests/functional/functional_test.php
@@ -19,7 +19,7 @@ class functional_test extends \phpbb_functional_test_case
 {
 	const FORUM_ID = 2;
 
-	static protected function setup_extensions()
+	protected static function setup_extensions()
 	{
 		return array('phpbb/topicprefixes');
 	}
@@ -128,7 +128,7 @@ class functional_test extends \phpbb_functional_test_case
 		$crawler = $crawler
 			->filter('table > tbody > tr')
 			->reduce(function (Crawler $node) use ($prefix_tag) {
-				return $node->filter('strong')->text() == $prefix_tag;
+				return $node->filter('strong')->text() === $prefix_tag;
 			});
 		$url = $crawler->selectLink($this->lang('ENABLED'))->link()->getUri();
 


### PR DESCRIPTION
Mostly just consists of switching over from the User to the Language object for handling language stuff.